### PR TITLE
build_image without dev

### DIFF
--- a/os/sdk-modifying-coreos.md
+++ b/os/sdk-modifying-coreos.md
@@ -154,7 +154,7 @@ Build all of the target binary packages:
 Build an image based on the binary packages built above, including development tools:
 
 ```sh
-./build_image dev
+./build_image
 ```
 
 After `build_image` completes, it prints commands for converting the raw bin into a bootable virtual machine. Run the `image_to_vm.sh` command.


### PR DESCRIPTION
Removed the dev arg in Render the CoreOS Container Linux image section. 

`./build_image dev` becomes `./build_image`
